### PR TITLE
fix: Fix a bug where forgetting trailing slash in memory bucket leads to undesired behaviour

### DIFF
--- a/mallm/agents/agent.py
+++ b/mallm/agents/agent.py
@@ -4,6 +4,7 @@ import dataclasses
 import dbm
 import json
 import logging
+import os
 import uuid
 from typing import TYPE_CHECKING, Optional
 
@@ -38,7 +39,9 @@ class Agent:
         self.short_id = self.id[:4]
         self.persona = persona
         self.persona_description = persona_description
-        self.memory_bucket = coordinator.memory_bucket_dir + f"agent_{self.id}"
+        self.memory_bucket = os.path.join(
+            coordinator.memory_bucket_dir, f"agent_{self.id}"
+        )
         self.coordinator = coordinator
         self.moderator = moderator
         self.llm = llm

--- a/mallm/coordinator.py
+++ b/mallm/coordinator.py
@@ -2,6 +2,7 @@ import dataclasses
 import dbm
 import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import Sequence
@@ -47,7 +48,7 @@ class Coordinator:
         self.use_moderator = use_moderator
         self.moderator: Optional[Moderator] = None
         self.memory_bucket_dir = memory_bucket_dir
-        self.memory_bucket = self.memory_bucket_dir + "global_" + self.id
+        self.memory_bucket = os.path.join(self.memory_bucket_dir, "global_" + self.id)
         self.decision_protocol: Optional[DecisionProtocol] = None
         self.llm = model
         self.response_generator: ResponseGenerator = SimpleResponseGenerator(self.llm)

--- a/mallm/utils/config.py
+++ b/mallm/utils/config.py
@@ -76,9 +76,11 @@ class Config:
             logger.error("HTTP Error: Could not connect to the provided endpoint url.")
             logger.error(e)
             sys.exit(1)
-
         if self.max_concurrent_requests > 500:
             logger.error(
                 "max_concurrent_requests is too large. TGI can only handle about 500 requests. Please make sure to leave computing for other poeple too. Recommended: ~250."
             )
             sys.exit(1)
+        if not os.path.exists(self.memory_bucket_dir):
+            os.makedirs(self.memory_bucket_dir)
+            logger.info(f"Created memory bucket directory: {self.memory_bucket_dir}")


### PR DESCRIPTION
If you did not add a trailing slash to the memory bucket directory, it would create files in the project folder because of poor path handling (no path join, just string adding).

In the future, it would be better to use pathlib.Path for this path handling otherwise weird behavior can happen.

I also made sure the bucket is created otherwise leading to another error.